### PR TITLE
Update host for .rocks zone because the old one fails.

### DIFF
--- a/src/Iodev/Whois/Config.php
+++ b/src/Iodev/Whois/Config.php
@@ -797,7 +797,7 @@ class Config
             [ "zone" => ".rio", "host" => "whois.gtlds.nic.br" ],
             [ "zone" => ".rip", "host" => "whois.rightside.co" ],
             [ "zone" => ".ro", "host" => "whois.rotld.ro", "parser" => '\Iodev\Whois\Parsers\FlatCommonParser' ],
-            [ "zone" => ".rocks", "host" => "whois.unitedtld.com" ],
+            [ "zone" => ".rocks", "host" => "whois.nic.rocks" ],
             [ "zone" => ".rodeo", "host" => "whois-dub.mm-registry.com" ],
             [ "zone" => ".rs", "host" => "whois.rnids.rs", "parser" => '\Iodev\Whois\Parsers\FlatCommonParser' ],
             [ "zone" => ".rsvp", "host" => "domain-registry-whois.l.google.com" ],


### PR DESCRIPTION
Update host for .rocks zone because the old one fails with message:
"unable to connect to whois.unitedtld.com:43 (No route to host)"
https://www.iana.org/domains/root/db/rocks.html