### PR TITLE
removed whois.meregistry.net

### DIFF
--- a/src/Iodev/Whois/Configs/module.tld.servers.json
+++ b/src/Iodev/Whois/Configs/module.tld.servers.json
@@ -518,7 +518,6 @@
   {"zone": ".marketing", "host": "whois.donuts.co"},
   {"zone": ".mc", "host": "whois.ripe.net"},
   {"zone": ".md", "host": "whois.nic.md"},
-  {"zone": ".me", "host": "whois.meregistry.net"},
   {"zone": ".me", "host": "whois.nic.me"},
   {"zone": ".med.ec", "host": "whois.lac.net"},
   {"zone": ".media", "host": "whois.donuts.co"},


### PR DESCRIPTION
meregistry.net is down and the oficial .me whois server is whois.nic.me: https://www.iana.org/domains/root/db/me.html

| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | yes/no
| New feature?  | yes/no <!-- please add use-case examples to README.md -->
| BC breaks?    | no
| Deprecations? | yes/no
| Tests pass?   | yes    <!-- please add some, will be required by reviewers -->
| Fixed tickets | #...   <!-- #-prefixed issue number(s), if any -->
| License       | MIT

<!--
Write a short README entry for your feature/bugfix here (replace this comment block.)
This will help to understand your PR.
-->
