### PR TITLE
correct undefined 0 error if variable $v is empty

### DIFF
--- a/src/Iodev/Whois/Helpers/ParserHelper.php
+++ b/src/Iodev/Whois/Helpers/ParserHelper.php
@@ -122,6 +122,11 @@ class ParserHelper
                     $k = '';
                 }
             }
+            if ($k== 0 && $v== 0) {
+                $dict[$k] = count($v) > 1 ? $v : $v[0];
+            } else {
+                $dict[] = $v;
+            }
             if (!empty($k)) {
                 $dict[$k] = count($v) > 1 ? $v : $v[0];
             } else {


### PR DESCRIPTION
correct undefined 0 error if variable $v is empty , example domains like are affected in this case 
"Registrant
  Organization: company

"

| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | yes
| New feature?  | no 
| BC breaks?    | no
| Deprecations? | no
| License       | MIT

<!--
undefined index 0 error appear on v for some registrant values.
forcing check helps getting output in these cases.
difference between "==0" and "!empty()" can interfere too, i preferred add an if with check on "==0", i left this to you  :)  
-->
