### PR TITLE
added .blog whois server

### DIFF
--- a/src/Iodev/Whois/Configs/module.tld.servers.json
+++ b/src/Iodev/Whois/Configs/module.tld.servers.json
@@ -67,6 +67,7 @@
   {"zone": ".bj", "host": "www.nic.bj"},
   {"zone": ".black", "host": "whois.afilias.net"},
   {"zone": ".blackfriday", "host": "whois.uniregistry.net"},
+  {"zone": ".blog", "host": "whois.nic.blog"},
   {"zone": ".blue", "host": "whois.afilias.net"},
   {"zone": ".bmw", "host": "whois.ksregistry.net"},
   {"zone": ".bn", "host": "whois.bn"},


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| License       | MIT

Added the ability to lookup .blog domains:

```php
$info = Whois::create()->loadDomainInfo("daveismyname.blog");
```
