### PR TITLE
Remove concrete parser for .cz zone

### DIFF
--- a/src/Iodev/Whois/Configs/module.tld.servers.json
+++ b/src/Iodev/Whois/Configs/module.tld.servers.json
@@ -167,7 +167,7 @@
   {"zone": ".cuisinella", "host": "whois.nic.cuisinella"},
   {"zone": ".cx", "host": "whois.nic.cx"},
   {"zone": ".cymru", "host": "whois.nic.cymru"},
-  {"zone": ".cz", "host": "whois.nic.cz", "parserType": "block"},
+  {"zone": ".cz", "host": "whois.nic.cz"},
   {"zone": ".dad", "host": "domain-registry-whois.l.google.com"},
   {"zone": ".dance", "host": "whois.unitedtld.com"},
   {"zone": ".dating", "host": "whois.donuts.co"},


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | yes
| New feature?  | no <!-- please add use-case examples to README.md -->
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes    <!-- please add some, will be required by reviewers -->
| Fixed tickets | #...   <!-- #-prefixed issue number(s), if any -->
| License       | MIT

<!--
Write a short README entry for your feature/bugfix here (replace this comment block.)
This will help to understand your PR.
-->

I am unable to load domain info for .cz zone. Method `loadDomainInfo` returns `null` instead of `DomainInfo` object. I got it running again by removing specific parser from configuration for this tld.