### PR TITLE
Remove html link from states

### DIFF
--- a/src/Iodev/Whois/Helpers/ParserHelper.php
+++ b/src/Iodev/Whois/Helpers/ParserHelper.php
@@ -260,7 +260,8 @@ class ParserHelper
         foreach ($rawstates as $rawstate) {
             if (preg_match('/^\s*((\d{3}\s+)?[a-z]{2,}.*)\s*/ui', $rawstate, $m)) {
                 $state = mb_strtolower($m[1]);
-                $state = $removeExtra ? trim(preg_replace('~\(.+?\)|http.+~ui', '', $state)) : $state;
+                $state = $removeExtra ? trim(preg_replace('~\(.+?\)|(http|<a href).+~ui', '', $state)) : $state;
+
                 if (!empty($state)) {
                     $states[] = $state;
                 }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #80
| License       | MIT

Quick and dirt new regex for the removal of links in html format from the states, as reported in issue #80 a piece of html was not removed since only the url was considered
