### PR TITLE
Change expiration date on .as test

### DIFF
--- a/tests/Iodev/Whois/Modules/Tld/parsing_data/.as/google.as.json
+++ b/tests/Iodev/Whois/Modules/Tld/parsing_data/.as/google.as.json
@@ -8,7 +8,7 @@
     "ns4.google.com"
   ],
   "creationDate": "2000-08-02T00:00",
-  "expirationDate": "2019-08-02T00:00",
+  "expirationDate": "2020-08-02T00:00",
   "states": [
     "active",
     "update prohibited by registrar",


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | yes
| New feature?  | no 
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| License       | MIT

Small modification to the test for the .as extension, the expiration date is relative and is calculated, updated to 2020 to pass the test successfully.

IMHO: To avoid continuous updates in the future you could also remove the expiry date from the test.