### PR TITLE
Add whois server for .xn--ses554g

### DIFF
--- a/src/Iodev/Whois/Configs/module.tld.servers.json
+++ b/src/Iodev/Whois/Configs/module.tld.servers.json
@@ -793,6 +793,7 @@
   {"zone": ".xn--q9jyb4c", "host": "domain-registry-whois.l.google.com"},
   {"zone": ".xn--qcka1pmc", "host": "domain-registry-whois.l.google.com"},
   {"zone": ".xn--rhqv96g", "host": "whois.nic.xn--rhqv96g"},
+  {"zone": ".xn--ses554g", "host": "whois.nic.xn--ses554g"},
   {"zone": ".xn--unup4y", "host": "whois.donuts.co"},
   {"zone": ".xn--vermgensberater-ctb", "host": "whois.nic.xn--vermgensberater-ctb"},
   {"zone": ".xn--vermgensberatung-pwb", "host": "whois.nic.xn--vermgensberatung-pwb"},

--- a/tests/Iodev/Whois/Modules/Tld/TldParsingTest.php
+++ b/tests/Iodev/Whois/Modules/Tld/TldParsingTest.php
@@ -741,6 +741,10 @@ class TldParsingTest extends \PHPUnit_Framework_TestCase
             [ "free.xn--p1ai", ".xn--p1ai/free.txt", null ],
             [ "xn--80a1acny.xn--p1ai", ".xn--p1ai/xn--80a1acny.xn--p1ai.txt", ".xn--p1ai/xn--80a1acny.xn--p1ai.json" ],
 
+            // .网址 (.xn--ses554g)
+            [ "free.xn--ses554g", ".xn--ses554g/free.txt", null ],
+            [ "google.xn--ses554g", ".xn--ses554g/google.xn--ses554g.txt", ".xn--ses554g/google.xn--ses554g.json" ],
+
             // .XIN
             [ "free.xin", ".xin/free.txt", null ],
             [ "microsoft.xin", ".xin/microsoft.xin.txt", ".xin/microsoft.xin.json" ],

--- a/tests/Iodev/Whois/Modules/Tld/parsing_data/.xn--ses554g/free.txt
+++ b/tests/Iodev/Whois/Modules/Tld/parsing_data/.xn--ses554g/free.txt
@@ -1,0 +1,35 @@
+The queried object does not exist: Common; No match.
+>>> Last update of WHOIS database: 2020-02-25T08:00:25Z <<<
+
+Status Codes: For more information on Whois status codes, please visit https://icann.org/epp
+
+NOTICE: The expiration date displayed in this record is the date the
+registrar's sponsorship of the domain name registration in the registry is
+currently set to expire. This date does not necessarily reflect the expiration
+date of the domain name registrant's agreement with the sponsoring
+registrar.  Users may consult the sponsoring registrar's Whois database to
+view the registrar's reported date of expiration for this registration.
+
+TERMS OF USE: You are not authorized to access or query our Whois
+database through the use of electronic processes that are high-volume and
+automated except as reasonably necessary to register domain names or
+modify existing registrations; the Data in KNET Global Registry
+Services' ("KNET") Whois database is provided by KNET for
+information purposes only, and to assist persons in obtaining information
+about or related to a domain name registration record. KNET does not
+guarantee its accuracy. By submitting a Whois query, you agree to abide
+by the following terms of use: You agree that you may use this Data only
+for lawful purposes and that under no circumstances will you use this Data
+to: (1) allow, enable, or otherwise support the transmission of mass
+unsolicited, commercial advertising or solicitations via e-mail, telephone,
+or facsimile; or (2) enable high volume, automated, electronic processes
+that apply to KNET (or its computer systems). The compilation,
+repackaging, dissemination or other use of this Data is expressly
+prohibited without the prior written consent of KNET. You agree not to
+use electronic processes that are automated and high-volume to access or
+query the Whois database except as reasonably necessary to register
+domain names or modify existing registrations. KNET reserves the right
+to restrict your access to the Whois database in its sole discretion to ensure
+operational stability.  KNET may restrict or terminate your access to the
+Whois database for failure to abide by these terms of use. KNET
+reserves the right to modify these terms at any time.

--- a/tests/Iodev/Whois/Modules/Tld/parsing_data/.xn--ses554g/google.xn--ses554g.json
+++ b/tests/Iodev/Whois/Modules/Tld/parsing_data/.xn--ses554g/google.xn--ses554g.json
@@ -1,0 +1,12 @@
+{
+  "domainName": "google.xn--ses554g",
+  "whoisServer": "whois.knetreg.cn",
+  "nameServers": [],
+  "creationDate": "2019-10-11T03:10:19Z",
+  "expirationDate": "2029-10-11T03:10:19Z",
+  "states": [
+    "inactive"
+  ],
+  "owner": "上海那兰陀投资有限公司",
+  "registrar": "Knet Registrar Co.,Ltd."
+}

--- a/tests/Iodev/Whois/Modules/Tld/parsing_data/.xn--ses554g/google.xn--ses554g.txt
+++ b/tests/Iodev/Whois/Modules/Tld/parsing_data/.xn--ses554g/google.xn--ses554g.txt
@@ -1,0 +1,67 @@
+Domain Name: google.xn--ses554g
+Internationalized Domain Name: google.网址
+Registry Domain ID: D20191011G10001G_20997132-wangzhi
+Registrar WHOIS Server: whois.knetreg.cn
+Registrar URL: http://knetreg.cn
+Updated Date:
+Creation Date: 2019-10-11T03:10:19Z
+Registry Expiry Date: 2029-10-11T03:10:19Z
+Registrar: Knet Registrar Co.,Ltd.
+Registrar IANA ID: 3225
+Registrar Abuse Contact Email: abuse@knetreg.cn
+Registrar Abuse Contact Phone: +86.4000800066
+Domain Status: inactive https://icann.org/epp#inactive
+Registry Registrant ID:
+Registrant Name:
+Registrant Organization: 上海那兰陀投资有限公司
+Registrant Street:
+Registrant City:
+Registrant State/Province: 上海
+Registrant Postal Code:
+Registrant Country: CN
+Registrant Phone:
+Registrant Phone Ext:
+Registrant Fax:
+Registrant Fax Ext:
+Registrant Email: Please query the RDDS service of the Registrar of Record  identified in this output for information on                                                                                          how to contact the Registrant, Admin, or Tech contact of the queried domain name.
+Registry Admin ID:
+Admin Name:
+Admin Organization:
+Admin Street:
+Admin City:
+Admin State/Province:
+Admin Postal Code:
+Admin Country:
+Admin Phone:
+Admin Phone Ext:
+Admin Fax:
+Admin Fax Ext:
+Admin Email: Please query the RDDS service of the Registrar of Record  identified in this output for information on how                                                                                          to contact the Registrant, Admin, or Tech contact of the queried domain name.
+Registry Tech ID:
+Tech Name:
+Tech Organization:
+Tech Street:
+Tech City:
+Tech State/Province:
+Tech Postal Code:
+Tech Country:
+Tech Phone:
+Tech Phone Ext:
+Tech Fax:
+Tech Fax Ext:
+Tech Email: Please query the RDDS service of the Registrar of Record  identified in this output for information on how to contact the Registrant, Admin, or Tech contact of the queried domain name.
+Name Server:
+DNSSEC: unsigned
+URL of the ICANN Whois Inaccuracy Complaint Form: https://www.icann.org/wicf/
+>>> Last update of WHOIS database: 2020-02-25T07:55:23Z <<<
+
+For more information on Whois status codes, please visit https://icann.org/epp
+
+NOTICE: The expiration date displayed in this record is the date the
+registrar's sponsorship of the domain name registration in the registry is
+currently set to expire. This date does not necessarily reflect the expiration
+date of the domain name registrant's agreement with the sponsoring
+registrar.  Users may consult the sponsoring registrar's Whois database to
+view the registrar's reported date of expiration for this registration.
+
+TERMS OF USE: .网址(.xn--ses554g) Registry Operator， has collected this information for the WHOIS database through an ICANN-Accredited Registrar and do not guarantee its accuracy or completeness. This information is provided to you only for lawful purposes， and under no circumstances should be used: (1) to allow， enable， or otherwise support the transmission of mass unsolicited， commercial advertising or solicitations via direct mail， electronic mail， or by telephone; (2) in contravention of any applicable data and privacy protection acts; or (3) to enable high volume， automated， electronic processes that apply to the registry (or its systems). Compilation， repackaging， dissemination， or other use of the WHOIS database in its entirety， or of a substantial portion thereof， is not allowed without .网址 registrys prior written permission. .网址 registry reserves the right to modify or change these conditions at any time without prior or subsequent notification of any kind. By executing this query， in any manner whatsoever， you agree to abide by these terms.


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | no 
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes    
| License       | MIT

Whois server for .vip domains, according to iana.org.