### PR TITLE
Update .cat whois server

### DIFF
--- a/src/Iodev/Whois/Configs/module.tld.servers.json
+++ b/src/Iodev/Whois/Configs/module.tld.servers.json
@@ -112,7 +112,7 @@
   {"zone": ".casa", "host": "whois.nic.casa"},
   {"zone": ".cash", "host": "whois.donuts.co"},
   {"zone": ".casino", "host": "whois.donuts.co"},
-  {"zone": ".cat", "host": "whois.cat"},
+  {"zone": ".cat", "host": "whois.nic.cat"},
   {"zone": ".catering", "host": "whois.donuts.co"},
   {"zone": ".cc", "host": "ccwhois.verisign-grs.com"},
   {"zone": ".cc", "host": "whois.nic.cc"},


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| License       | MIT

Update whois server for `.cat` domains. Server changed from `whois.cat` to `whois.nic.cat`.
