### PR TITLE
Add whois server for .icu

### DIFF
--- a/src/Iodev/Whois/Configs/module.tld.servers.json
+++ b/src/Iodev/Whois/Configs/module.tld.servers.json
@@ -332,6 +332,7 @@
   {"zone": ".ht", "host": "whois.nic.ht"},
   {"zone": ".hu", "host": "whois.nic.hu"},
   {"zone": ".ibm", "host": "whois.nic.ibm"},
+  {"zone": ".icu", "host": "whois.nic.icu"},
   {"zone": ".id", "host": "whois.pandi.or.id"},
   {"zone": ".*.id", "host": "whois.idnic.net.id"},
   {"zone": ".ie", "host": "whois.domainregistry.ie", "parserType": "block"},

--- a/tests/Iodev/Whois/Modules/Tld/TldParsingTest.php
+++ b/tests/Iodev/Whois/Modules/Tld/TldParsingTest.php
@@ -393,6 +393,10 @@ class TldParsingTest extends TestCase
             [ "free.hu", ".hu/free.txt", null ],
             [ "google.hu", ".hu/google.hu.txt", ".hu/google.hu.json" ],
 
+            // .ICU
+            [ "free.icu", ".icu/free.txt", null ],
+            [ "google.icu", ".icu/google.icu.txt", ".icu/google.icu.json" ],
+
             // .ID
             [ "free.id", ".id/free.txt", null ],
             [ "google.co.id", ".id/google.co.id.txt", ".id/google.co.id.json" ],

--- a/tests/Iodev/Whois/Modules/Tld/parsing_data/.icu/free.txt
+++ b/tests/Iodev/Whois/Modules/Tld/parsing_data/.icu/free.txt
@@ -1,0 +1,21 @@
+The queried object does not exist: previous registration D79017889-CNIC was purged on 2019-12-30T23:18:42.0Z (DOMAIN NOT FOUND)
+
+>>> Last update of WHOIS database: 2020-03-12T08:01:22.0Z <<<
+
+For more information on Whois status codes, please visit https://icann.org/epp
+
+>>> IMPORTANT INFORMATION ABOUT THE DEPLOYMENT OF RDAP: please visit
+https://www.centralnic.com/support/rdap <<<
+
+The Whois and RDAP services are provided by CentralNic, and contain
+information pertaining to Internet domain names registered by our
+our customers. By using this service you are agreeing (1) not to use any
+information presented here for any purpose other than determining
+ownership of domain names, (2) not to store or reproduce this data in
+any way, (3) not to use any high-volume, automated, electronic processes
+to obtain data from this service. Abuse of this service is monitored and
+actions in contravention of these terms will result in being permanently
+blacklisted. All data is (c) CentralNic Ltd (https://www.centralnic.com)
+
+Access to the Whois and RDAP services is rate limited. For more
+information, visit https://registrar-console.centralnic.com/pub/whois_guidance.

--- a/tests/Iodev/Whois/Modules/Tld/parsing_data/.icu/google.icu.json
+++ b/tests/Iodev/Whois/Modules/Tld/parsing_data/.icu/google.icu.json
@@ -1,0 +1,19 @@
+{
+  "domainName": "google.icu",
+  "whoisServer": "whois.markmonitor.com",
+  "nameServers": [
+    "ns1.googledomains.com",
+    "ns2.googledomains.com",
+    "ns3.googledomains.com",
+    "ns4.googledomains.com"
+  ],
+  "creationDate": "2018-04-24T10:06:03-0700",
+  "expirationDate": "2020-04-24T00:00:00-0700",
+  "states": [
+    "clientupdateprohibited",
+    "clienttransferprohibited",
+    "clientdeleteprohibited"
+  ],
+  "owner": "Google LLC",
+  "registrar": "MarkMonitor, Inc."
+}

--- a/tests/Iodev/Whois/Modules/Tld/parsing_data/.icu/google.icu.txt
+++ b/tests/Iodev/Whois/Modules/Tld/parsing_data/.icu/google.icu.txt
@@ -1,0 +1,82 @@
+Domain Name: google.icu
+Registry Domain ID: D66309549-CNIC
+Registrar WHOIS Server: whois.markmonitor.com
+Registrar URL: http://www.markmonitor.com
+Updated Date: 2019-11-07T09:16:24-0800
+Creation Date: 2018-04-24T10:06:03-0700
+Registrar Registration Expiration Date: 2020-04-24T00:00:00-0700
+Registrar: MarkMonitor, Inc.
+Registrar IANA ID: 292
+Registrar Abuse Contact Email: abusecomplaints@markmonitor.com
+Registrar Abuse Contact Phone: +1.2083895770
+Domain Status: clientUpdateProhibited (https://www.icann.org/epp#clientUpdateProhibited)
+Domain Status: clientTransferProhibited (https://www.icann.org/epp#clientTransferProhibited)
+Domain Status: clientDeleteProhibited (https://www.icann.org/epp#clientDeleteProhibited)
+Registrant Organization: Google LLC
+Registrant State/Province: CA
+Registrant Country: US
+Registrant Email: Select Request Email Form at https://domains.markmonitor.com/whois/google.icu
+Admin Organization: Google LLC
+Admin State/Province: CA
+Admin Country: US
+Admin Email: Select Request Email Form at https://domains.markmonitor.com/whois/google.icu
+Tech Organization: Google LLC
+Tech State/Province: CA
+Tech Country: US
+Tech Email: Select Request Email Form at https://domains.markmonitor.com/whois/google.icu
+Name Server: ns3.googledomains.com
+Name Server: ns1.googledomains.com
+Name Server: ns4.googledomains.com
+Name Server: ns2.googledomains.com
+DNSSEC: unsigned
+URL of the ICANN WHOIS Data Problem Reporting System: http://wdprs.internic.net/
+>>> Last update of WHOIS database: 2020-03-12T01:03:37-0700 <<<
+
+For more information on WHOIS status codes, please visit:
+  https://www.icann.org/resources/pages/epp-status-codes
+
+If you wish to contact this domain’s Registrant, Administrative, or Technical
+contact, and such email address is not visible above, you may do so via our web
+form, pursuant to ICANN’s Temporary Specification. To verify that you are not a
+robot, please enter your email address to receive a link to a page that
+facilitates email communication with the relevant contact(s).
+
+Web-based WHOIS:
+  https://domains.markmonitor.com/whois
+
+If you have a legitimate interest in viewing the non-public WHOIS details, send
+your request and the reasons for your request to whoisrequest@markmonitor.com
+and specify the domain name in the subject line. We will review that request and
+may ask for supporting documentation and explanation.
+
+The data in MarkMonitor’s WHOIS database is provided for information purposes,
+and to assist persons in obtaining information about or related to a domain
+name’s registration record. While MarkMonitor believes the data to be accurate,
+the data is provided "as is" with no guarantee or warranties regarding its
+accuracy.
+
+By submitting a WHOIS query, you agree that you will use this data only for
+lawful purposes and that, under no circumstances will you use this data to:
+  (1) allow, enable, or otherwise support the transmission by email, telephone,
+or facsimile of mass, unsolicited, commercial advertising, or spam; or
+  (2) enable high volume, automated, or electronic processes that send queries,
+data, or email to MarkMonitor (or its systems) or the domain name contacts (or
+its systems).
+
+MarkMonitor.com reserves the right to modify these terms at any time.
+
+By submitting this query, you agree to abide by this policy.
+
+MarkMonitor is the Global Leader in Online Brand Protection.
+
+MarkMonitor Domain Management(TM)
+MarkMonitor Brand Protection(TM)
+MarkMonitor AntiCounterfeiting(TM)
+MarkMonitor AntiPiracy(TM)
+MarkMonitor AntiFraud(TM)
+Professional and Managed Services
+
+Visit MarkMonitor at https://www.markmonitor.com
+Contact us at +1.8007459229
+In Europe, at +44.02032062220
+--


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes   
| License       | MIT

Whois server for .icu domains, according to iana.org.