### PR TITLE
Add whois server for .earth

### DIFF
--- a/src/Iodev/Whois/Configs/module.tld.servers.json
+++ b/src/Iodev/Whois/Configs/module.tld.servers.json
@@ -205,6 +205,7 @@
   {"zone": ".durban", "host": "durban-whois.registry.net.za"},
   {"zone": ".dvag", "host": "whois.nic.dvag"},
   {"zone": ".dz", "host": "whois.nic.dz"},
+  {"zone": ".earth", "host": "whois.nic.earth"},
   {"zone": ".eat", "host": "domain-registry-whois.l.google.com"},
   {"zone": ".ec", "host": "whois.nic.ec"},
   {"zone": ".*.ec", "host": "whois.lac.net"},

--- a/tests/Iodev/Whois/Modules/Tld/TldParsingTest.php
+++ b/tests/Iodev/Whois/Modules/Tld/TldParsingTest.php
@@ -311,6 +311,10 @@ class TldParsingTest extends TestCase
             [ "free.dz", ".dz/free.txt", null ],
             [ "google.dz", ".dz/google.dz.txt", ".dz/google.dz.json" ],
 
+            // .EARTH
+            [ "free.earth", ".earth/free.txt", null ],
+            [ "google.earth", ".earth/google.earth.txt", ".earth/google.earth.json" ],
+
             // .EC
             [ "free.ec", ".ec/free.txt", null ],
             // [ "google.com.ec", ".ec/google.com.ec.txt", ".ec/google.com.ec.json" ],

--- a/tests/Iodev/Whois/Modules/Tld/parsing_data/.earth/free.txt
+++ b/tests/Iodev/Whois/Modules/Tld/parsing_data/.earth/free.txt
@@ -1,0 +1,11 @@
+No Data Found
+URL of the ICANN Whois Inaccuracy Complaint Form: https://www.icann.org/wicf/
+>>> Last update of WHOIS database: 2020-03-12T10:03:10Z <<<
+The above WHOIS results have been redacted to remove potential personal data. The full WHOIS output may be available to individuals and organisations with a legitimate interest in accessing this data not outweighed by the fundamental privacy rights of the data subject. To find out more, or to make a request for access, please visit: RDDSrequest.nic.earth.
+For more information on Whois status codes, please visit https://icann.org/epp
+
+Interlink Co., Ltd., ("Interlink") the Registry Operator for .EARTH, has collected this information for the WHOIS database through an ICANN-Accredited Registrar. This information is provided to you for informational purposes only and is designed to assist persons in determining contents of a domain name registration record in the .EARTH registry database. Interlink makes this information available to you "as is" and does not guarantee its accuracy. By submitting a WHOIS query, you agree that you will use this data only for lawful purposes and that, under no circumstances will you use this data: (1) to allow, enable, or otherwise support the transmission of mass unsolicited, commercial advertising or solicitations via direct mail, electronic mail, or by telephone; (2) in contravention of any applicable data and privacy protection acts; or (3) to enable high volume, automated, electronic processes that apply to the registry (or its systems). Compilation, repackaging, dissemination, or other use of the WHOIS database in its entirety, or of a substantial portion thereof, is not allowed without Interlink's prior written permission.
+
+Interlink reserves the right to modify or change these conditions at any time without prior or subsequent notification of any kind. By executing this query, in any manner whatsoever, you agree to abide by these terms.
+
+NOTE: FAILURE TO LOCATE A RECORD IN THE WHOIS DATABASE IS NOT INDICATIVE OF THE AVAILABILITY OF A DOMAIN NAME.

--- a/tests/Iodev/Whois/Modules/Tld/parsing_data/.earth/google.earth.json
+++ b/tests/Iodev/Whois/Modules/Tld/parsing_data/.earth/google.earth.json
@@ -1,0 +1,19 @@
+{
+  "domainName": "google.earth",
+  "whoisServer": "",
+  "nameServers": [
+    "ns1.google.com",
+    "ns2.google.com",
+    "ns3.google.com",
+    "ns4.google.com"
+  ],
+  "creationDate": "2015-10-07T21:14:04Z",
+  "expirationDate": "2020-10-06T23:59:59Z",
+  "states": [
+    "clientdeleteprohibited",
+    "clientupdateprohibited",
+    "clienttransferprohibited"
+  ],
+  "owner": "Google LLC",
+  "registrar": "MarkMonitor, Inc."
+}

--- a/tests/Iodev/Whois/Modules/Tld/parsing_data/.earth/google.earth.txt
+++ b/tests/Iodev/Whois/Modules/Tld/parsing_data/.earth/google.earth.txt
@@ -1,0 +1,75 @@
+Domain Name: google.earth
+Registry Domain ID: D5563-EARTH
+Registrar WHOIS Server:
+Registrar URL: www.markmonitor.com
+Updated Date: 2019-09-09T09:37:20Z
+Creation Date: 2015-10-07T21:14:04Z
+Registry Expiry Date: 2020-10-06T23:59:59Z
+Registrar: MarkMonitor, Inc.
+Registrar IANA ID: 292
+Registrar Abuse Contact Email: abusecomplaints@markmonitor.com
+Registrar Abuse Contact Phone: +1.2083895740
+Domain Status: clientDeleteProhibited https://icann.org/epp#clientDeleteProhibited
+Domain Status: clientUpdateProhibited https://icann.org/epp#clientUpdateProhibited
+Domain Status: clientTransferProhibited https://icann.org/epp#clientTransferProhibited
+Registry Registrant ID:
+Registrant Name:
+Registrant Organization: Google LLC
+Registrant Street:
+Registrant Street:
+Registrant Street:
+Registrant City:
+Registrant State/Province: CA
+Registrant Postal Code:
+Registrant Country: US
+Registrant Phone:
+Registrant Phone Ext:
+Registrant Fax:
+Registrant Fax Ext:
+Registrant Email: Please query the RDDS service of the Registrar of Record identified in this output for information on how to contact the Registrant, Admin, or Tech contact of the
+queried domain name.
+Registry Admin ID:
+Admin Name:
+Admin Organization:
+Admin Street:
+Admin Street:
+Admin Street:
+Admin City:
+Admin State/Province:
+Admin Postal Code:
+Admin Country:
+Admin Phone:
+Admin Phone Ext:
+Admin Fax:
+Admin Fax Ext:
+Admin Email: Please query the RDDS service of the Registrar of Record identified in this output for information on how to contact the Registrant, Admin, or Tech contact of the queried domain name.
+Registry Tech ID:
+Tech Name:
+Tech Organization:
+Tech Street:
+Tech Street:
+Tech Street:
+Tech City:
+Tech State/Province:
+Tech Postal Code:
+Tech Country:
+Tech Phone:
+Tech Phone Ext:
+Tech Fax:
+Tech Fax Ext:
+Tech Email: Please query the RDDS service of the Registrar of Record identified in this output for information on how to contact the Registrant, Admin, or Tech contact of the queried domain name.
+Name Server: ns3.google.com
+Name Server: ns1.google.com
+Name Server: ns2.google.com
+Name Server: ns4.google.com
+DNSSEC: unsigned
+URL of the ICANN Whois Inaccuracy Complaint Form: https://www.icann.org/wicf/
+>>> Last update of WHOIS database: 2020-03-12T10:05:32Z <<<
+The above WHOIS results have been redacted to remove potential personal data. The full WHOIS output may be available to individuals and organisations with a legitimate interest in accessing this data not outweighed by the fundamental privacy rights of the data subject. To find out more, or to make a request for access, please visit: RDDSrequest.nic.earth.
+For more information on Whois status codes, please visit https://icann.org/epp
+
+Interlink Co., Ltd., ("Interlink") the Registry Operator for .EARTH, has collected this information for the WHOIS database through an ICANN-Accredited Registrar. This information is provided to you for informational purposes only and is designed to assist persons in determining contents of a domain name registration record in the .EARTH registry database. Interlink makes this information available to you "as is" and does not guarantee its accuracy. By submitting a WHOIS query, you agree that you will use this data only for lawful purposes and that, under no circumstances will you use this data: (1) to allow, enable, or otherwise support the transmission of mass unsolicited, commercial advertising or solicitations via direct mail, electronic mail, or by telephone; (2) in contravention of any applicable data and privacy protection acts; or (3) to enable high volume, automated, electronic processes that apply to the registry (or its systems). Compilation, repackaging, dissemination, or other use of the WHOIS database in its entirety, or of a substantial portion thereof, is not allowed without Interlink's prior written permission.
+
+Interlink reserves the right to modify or change these conditions at any time without prior or subsequent notification of any kind. By executing this query, in any manner whatsoever, you agree to abide by these terms.
+
+NOTE: FAILURE TO LOCATE A RECORD IN THE WHOIS DATABASE IS NOT INDICATIVE OF THE AVAILABILITY OF A DOMAIN NAME.


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes    
| License       | MIT

IANA does not show a whois server, but **whois.nic.earth** answers correctly, it is not shown even on https://domain.earth where there is the web version https://whois.nic.earth
