### PR TITLE
Add whois server for .llc

### DIFF
--- a/src/Iodev/Whois/Configs/module.tld.servers.json
+++ b/src/Iodev/Whois/Configs/module.tld.servers.json
@@ -409,6 +409,7 @@
   {"zone": ".limo", "host": "whois.donuts.co"},
   {"zone": ".link", "host": "whois.uniregistry.net"},
   {"zone": ".live", "host": "whois.nic.live"},
+  {"zone": ".llc", "host": "whois.afilias.net"},
   {"zone": ".loans", "host": "whois.donuts.co"},
   {"zone": ".london", "host": "whois-lon.mm-registry.com"},
   {"zone": ".london", "host": "whois.nic.london"},

--- a/tests/Iodev/Whois/Modules/Tld/TldParsingTest.php
+++ b/tests/Iodev/Whois/Modules/Tld/TldParsingTest.php
@@ -493,6 +493,10 @@ class TldParsingTest extends TestCase
             [ "free.live", ".live/free.txt", null ],
             [ "microsoft.live", ".live/microsoft.live.txt", ".live/microsoft.live.json" ],
 
+            // .LLC
+            [ "free.llc", ".llc/free.txt", null ],
+            [ "google.llc", ".llc/google.llc.txt", ".llc/google.llc.json" ],
+
             // .LT
             [ "free.lt", ".lt/free.txt", null ],
             [ "google.lt", ".lt/google.lt.txt", ".lt/google.lt.json" ],

--- a/tests/Iodev/Whois/Modules/Tld/parsing_data/.llc/free.txt
+++ b/tests/Iodev/Whois/Modules/Tld/parsing_data/.llc/free.txt
@@ -1,0 +1,6 @@
+NOT FOUND
+>>> Last update of WHOIS database: 2020-05-06T07:50:11Z <<<
+
+Access to AFILIAS WHOIS information is provided to assist persons in determining the contents of a domain name registration record in the Afilias registry database. The data in this record is provided by Afilias Limited for informational purposes only, and Afilias does not guarantee its accuracy.  This service is intended only for query-based access. You agree that you will use this data only for lawful purposes and that, under no circumstances will you use this data to(a) allow, enable, or otherwise support the transmission by e-mail, telephone, or facsimile of mass unsolicited, commercial advertising or solicitations to entities other than the data recipient's own existing customers; or (b) enable high volume, automated, electronic processes that send queries or data to the systems of Registry Operator, a Registrar, or Afilias except as reasonably necessary to register domain names or modify existing registrations. All rights reserved. Afilias reserves the right to modify these terms at any time. By submitting this query, you agree to abide by this policy.
+
+The Registrar of Record identified in this output may have an RDDS service that can be queried for additional information on how to contact the Registrant, Admin, or Tech contact of the queried domain name.

--- a/tests/Iodev/Whois/Modules/Tld/parsing_data/.llc/google.llc.json
+++ b/tests/Iodev/Whois/Modules/Tld/parsing_data/.llc/google.llc.json
@@ -1,0 +1,20 @@
+{
+  "domainName": "google.llc",
+  "whoisServer": "whois.markmonitor.com",
+  "nameServers": [
+    "ns1.googledomains.com",
+    "ns2.googledomains.com",
+    "ns3.googledomains.com",
+    "ns4.googledomains.com"
+],
+  "creationDate": "2018-06-05T17:04:02Z",
+  "expirationDate": "2021-06-05T17:04:02Z",
+  "states": [
+    "clientdeleteprohibited",
+    "clienttransferprohibited",
+    "clientupdateprohibited",
+    "renewperiod"
+  ],
+  "owner": "Google LLC",
+  "registrar": "MarkMonitor Inc."
+}

--- a/tests/Iodev/Whois/Modules/Tld/parsing_data/.llc/google.llc.txt
+++ b/tests/Iodev/Whois/Modules/Tld/parsing_data/.llc/google.llc.txt
@@ -1,0 +1,33 @@
+Domain Name: GOOGLE.LLC
+Registry Domain ID: D503300000104800918-LRMS
+Registrar WHOIS Server: whois.markmonitor.com
+Registrar URL: http://www.markmonitor.com
+Updated Date: 2020-05-04T09:28:29Z
+Creation Date: 2018-06-05T17:04:02Z
+Registry Expiry Date: 2021-06-05T17:04:02Z
+Registrar Registration Expiration Date:
+Registrar: MarkMonitor Inc.
+Registrar IANA ID: 292
+Registrar Abuse Contact Email: abusecomplaints@markmonitor.com
+Registrar Abuse Contact Phone: +1.2083895740
+Reseller:
+Domain Status: clientDeleteProhibited https://icann.org/epp#clientDeleteProhibited
+Domain Status: clientTransferProhibited https://icann.org/epp#clientTransferProhibited
+Domain Status: clientUpdateProhibited https://icann.org/epp#clientUpdateProhibited
+Domain Status: renewPeriod https://icann.org/epp#renewPeriod
+Registrant Organization: Google LLC
+Registrant State/Province: CA
+Registrant Country: US
+Name Server: NS3.GOOGLEDOMAINS.COM
+Name Server: NS1.GOOGLEDOMAINS.COM
+Name Server: NS2.GOOGLEDOMAINS.COM
+Name Server: NS4.GOOGLEDOMAINS.COM
+DNSSEC: unsigned
+URL of the ICANN Whois Inaccuracy Complaint Form is https://www.icann.org/wicf/
+>>> Last update of WHOIS database: 2020-05-06T07:49:07Z <<<
+
+For more information on Whois status codes, please visit https://icann.org/epp
+
+Access to AFILIAS WHOIS information is provided to assist persons in determining the contents of a domain name registration record in the Afilias registry database. The data in this record is provided by Afilias Limited for informational purposes only, and Afilias does not guarantee its accuracy.  This service is intended only for query-based access. You agree that you will use this data only for lawful purposes and that, under no circumstances will you use this data to(a) allow, enable, or otherwise support the transmission by e-mail, telephone, or facsimile of mass unsolicited, commercial advertising or solicitations to entities other than the data recipient's own existing customers; or (b) enable high volume, automated, electronic processes that send queries or data to the systems of Registry Operator, a Registrar, or Afilias except as reasonably necessary to register domain names or modify existing registrations. All rights reserved. Afilias reserves the right to modify these terms at any time. By submitting this query, you agree to abide by this policy.
+
+The Registrar of Record identified in this output may have an RDDS service that can be queried for additional information on how to contact the Registrant, Admin, or Tech contact of the queried domain name.


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes   
| License       | MIT

Whois server for .llc domains, by Afilias registry.
