### PR TITLE
Fix SocketLoader timeout

### DIFF
--- a/src/Iodev/Whois/Loaders/SocketLoader.php
+++ b/src/Iodev/Whois/Loaders/SocketLoader.php
@@ -58,13 +58,16 @@ class SocketLoader implements ILoader
         if (!$handle) {
             throw new ConnectionException($errstr, $errno);
         }
+        
+        stream_set_timeout($handle, $this->timeout);
+        
         if (false === fwrite($handle, $query)) {
             throw new ConnectionException("Query cannot be written");
         }
         $text = "";
         while (!feof($handle)) {
             $chunk = fread($handle, 8192);
-            if (false === $chunk) {
+            if (false === $chunk || $chunk === '') {
                 throw new ConnectionException("Response chunk cannot be read");
             }
             $text .= $chunk;


### PR DESCRIPTION
This commit fixes two issues

1) We need to call stream_set_timeout($handle) to handle socket read timeout, because fsockopen($whoisHost, 43, $errno, $errstr, $this->timeout) is only for establishing connection, not for reading/writing
2) Seems like feof not working correctly on timeout. It continues to return FALSE event after timeout. fread returns empty string and infinite loop occurs. This is very dangerous bug

| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | don't know
| Fixed tickets | -
| License       | MIT
