### PR TITLE
Update module.tld.servers.json

### DIFF
--- a/src/Iodev/Whois/Configs/module.tld.servers.json
+++ b/src/Iodev/Whois/Configs/module.tld.servers.json
@@ -525,6 +525,7 @@
   {"zone": ".parts", "host": "whois.donuts.co"},
   {"zone": ".pe", "host": "kero.yachay.pe"},
   {"zone": ".pf", "host": "whois.registry.pf"},
+  {"zone": ".ph", "host": "whois.dot.ph"},
   {"zone": ".photo", "host": "whois.uniregistry.net"},
   {"zone": ".photography", "host": "whois.donuts.co"},
   {"zone": ".photos", "host": "whois.donuts.co"},


### PR DESCRIPTION
This change adds the tld .ph (the Philipines country domain suffix) and associates it with the appropriate WHOIS server: whois.dot.ph

  {"zone": ".ph", "host": "whois.dot.ph"},

| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | yes <!-- please add use-case examples to README.md -->
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes    <!-- please add some, will be required by reviewers -->
| Fixed tickets | #...   <!-- #-prefixed issue number(s), if any -->
| License       | MIT

<!--
Write a short README entry for your feature/bugfix here (replace this comment block.)
This will help to understand your PR.
-->
