### PR TITLE
SocketLoader: safer check for timeout?

### DIFF
--- a/src/Iodev/Whois/Loaders/SocketLoader.php
+++ b/src/Iodev/Whois/Loaders/SocketLoader.php
@@ -58,16 +58,16 @@ class SocketLoader implements ILoader
         if (!$handle) {
             throw new ConnectionException($errstr, $errno);
         }
-        
+
         stream_set_timeout($handle, $this->timeout);
-        
+
         if (false === fwrite($handle, $query)) {
             throw new ConnectionException("Query cannot be written");
         }
         $text = "";
         while (!feof($handle)) {
             $chunk = fread($handle, 8192);
-            if (false === $chunk || $chunk === '') {
+            if (false === $chunk || stream_get_meta_data($handle)['timed_out']) {
                 throw new ConnectionException("Response chunk cannot be read");
             }
             $text .= $chunk;


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | yes/no
| New feature?  |no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #136, #139, #151
| License       | MIT

`fread` returning empty string is valid thing to happen and shouldn't be used to detect timeouts.

Since `stream_set_timeout` is applied, timeout should be checked via `stream_get_meta_data`.