### PR TITLE
Added key for parsing KR registrar

### DIFF
--- a/src/Iodev/Whois/Configs/module.tld.parser.block.json
+++ b/src/Iodev/Whois/Configs/module.tld.parser.block.json
@@ -65,7 +65,8 @@
     "~^(Name|Last[-_\\s]Name|First[-_\\s]Name|Descr)$~ui"
   ],
   "registrarKeys": [
-    "~^(Current|Sponsoring)?[-_\\s]?Registr?ar[-_\\s]?(Name|Organization|Handle|Created)?$~ui"
+    "~^(Current|Sponsoring)?[-_\\s]?Registr?ar[-_\\s]?(Name|Organization|Handle|Created)?$~ui",
+    "~^Authorized[\\s]Agency$~ui"
   ],
   "statesKeys": [
     "~^(Domain|Registry|Registration|Ren|Epp)[-_\\s]?(Status|State)$~ui",

--- a/src/Iodev/Whois/Configs/module.tld.parser.common.json
+++ b/src/Iodev/Whois/Configs/module.tld.parser.common.json
@@ -58,7 +58,8 @@
     "~^(Name|Last[-_\\s]Name|First[-_\\s]Name|Descr)$~ui"
   ],
   "registrarKeys": [
-    "~^(Current|Sponsoring)?[-_\\s]?Registr?ar[-_\\s]?(Name|Organization|Handle|Created)?$~ui"
+    "~^(Current|Sponsoring)?[-_\\s]?Registr?ar[-_\\s]?(Name|Organization|Handle|Created)?$~ui",
+    "~^Authorized[\\s]Agency$~ui"
   ],
   "statesKeys": [
     "~^(Domain|Registry|Registration|Ren|Epp)[-_\\s]?(Status|State)$~ui",

--- a/src/Iodev/Whois/Configs/module.tld.parser.indent.json
+++ b/src/Iodev/Whois/Configs/module.tld.parser.indent.json
@@ -65,7 +65,8 @@
     "~^(Name|Last[-_\\s]Name|First[-_\\s]Name|Descr)$~ui"
   ],
   "registrarKeys": [
-    "~^(Current|Sponsoring)?[-_\\s]?Registr?ar[-_\\s]?(Name|Organization|Handle|Created)?$~ui"
+    "~^(Current|Sponsoring)?[-_\\s]?Registr?ar[-_\\s]?(Name|Organization|Handle|Created)?$~ui",
+    "~^Authorized[\\s]Agency$~ui"
   ],
   "statesKeys": [
     "~^(Domain|Registry|Registration|Ren|Epp)[-_\\s]?(Status|State)$~ui",

--- a/tests/Iodev/Whois/Modules/Tld/parsing_data/.kr/google.co.kr.json
+++ b/tests/Iodev/Whois/Modules/Tld/parsing_data/.kr/google.co.kr.json
@@ -9,9 +9,9 @@
   ],
   "dnssec": "unsigned",
   "creationDate": "1999-07-28T00:00:00",
-  "expirationDate": "2018-07-28T00:00:00",
+  "expirationDate": "2022-07-28T00:00:00",
   "updatedDate": "2010-10-04T00:00:00",
   "states": [],
   "owner": "Google Korea, LLC",
-  "registrar": ""
+  "registrar": "Whois Corp.(http://whois.co.kr)"
 }

--- a/tests/Iodev/Whois/Modules/Tld/parsing_data/.kr/google.co.kr.txt
+++ b/tests/Iodev/Whois/Modules/Tld/parsing_data/.kr/google.co.kr.txt
@@ -12,7 +12,7 @@ query : google.co.kr
 책임자 전화번호             : 82.25319000
 등록일                      : 1999. 07. 28.
 최근 정보 변경일            : 2010. 10. 04.
-사용 종료일                 : 2018. 07. 28.
+사용 종료일                 : 2022. 07. 28.
 정보공개여부                : Y
 등록대행자                  : (주)후이즈(http://whois.co.kr)
 DNSSEC                      : 미서명
@@ -39,7 +39,7 @@ AC E-Mail                   : dns-admin@google.com
 AC Phone Number             : 82.25319000
 Registered Date             : 1999. 07. 28.
 Last Updated Date           : 2010. 10. 04.
-Expiration Date             : 2018. 07. 28.
+Expiration Date             : 2022. 07. 28.
 Publishes                   : Y
 Authorized Agency           : Whois Corp.(http://whois.co.kr)
 DNSSEC                      : unsigned
@@ -53,6 +53,4 @@ Secondary Name Server
    Host Name                : ns4.google.com
 
 
-
 - KISA/KRNIC WHOIS Service -
-


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| License       | MIT

Added key to properly parse KR registrar where **Authorized Agency** label is used 