### PR TITLE
Update module.tld.servers.json

### DIFF
--- a/src/Iodev/Whois/Configs/module.tld.servers.json
+++ b/src/Iodev/Whois/Configs/module.tld.servers.json
@@ -313,7 +313,7 @@
   {"zone": ".discount", "host": "whois.nic.discount"},
   {"zone": ".dish", "host": "whois.nic.dish"},
   {"zone": ".diy", "host": "whois.nic.diy"},
-  {"zone": ".dk", "host": "whois.dk-hostmaster.dk", "parserType": "block"},
+  {"zone": ".dk", "host": "whois.dk-hostmaster.dk", "parserType": "block", "queryFormat": "--show-handles %s\r\n"},
   {"zone": ".dm", "host": "whois.nic.dm", "parserType": "commonFlat"},
   {"zone": ".dnp", "host": "whois.nic.dnp"},
   {"zone": ".do", "host": "whois.nic.do"},


### PR DESCRIPTION
When querying `whois.dk-hostmaster.dk` automatically add the flag `--show-handles` to get owner information as described at https://manpages.debian.org/jessie/whois/whois.1.en.html#NOTES

| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| License       | MIT


