### PR TITLE
Add whois server for .com.se

### DIFF
--- a/src/Iodev/Whois/Configs/module.tld.servers.json
+++ b/src/Iodev/Whois/Configs/module.tld.servers.json
@@ -974,6 +974,7 @@
   {"zone": ".scjohnson", "host": "whois.nic.scjohnson"},
   {"zone": ".scot", "host": "whois.nic.scot"},
   {"zone": ".se", "host": "whois.iis.se"},
+  {"zone": ".com.se", "host": "whois.centralnic.com"},
   {"zone": ".search", "host": "whois.nic.google"},
   {"zone": ".seat", "host": "whois.nic.seat"},
   {"zone": ".secure", "host": "whois.nic.secure"},

--- a/tests/Iodev/Whois/Modules/Tld/TldParsingTest.php
+++ b/tests/Iodev/Whois/Modules/Tld/TldParsingTest.php
@@ -831,6 +831,10 @@ class TldParsingTest extends TestCase
             [ "öppettider.se", ".se/xn--ppettider-z7a.se.txt", ".se/xn--ppettider-z7a.se.json" ],
             [ "xn--ppettider-z7a.se", ".se/xn--ppettider-z7a.se.txt", ".se/xn--ppettider-z7a.se.json" ],
 
+            // .COM.SE
+            [ "free.com.se", ".com.se/free.txt", null ],
+            [ "www.com.se", ".com.se/www.com.se.txt", ".com.se/www.com.se.json" ],
+
             // .SG
             [ "free.sg", ".sg/free.txt", null ],
             // [ "google.com.sg", ".sg/google.com.sg.txt", ".sg/google.com.sg.json" ],

--- a/tests/Iodev/Whois/Modules/Tld/parsing_data/.com.se/free.txt
+++ b/tests/Iodev/Whois/Modules/Tld/parsing_data/.com.se/free.txt
@@ -1,0 +1,1 @@
+\'free.com.se\' not found

--- a/tests/Iodev/Whois/Modules/Tld/parsing_data/.com.se/www.com.se.json
+++ b/tests/Iodev/Whois/Modules/Tld/parsing_data/.com.se/www.com.se.json
@@ -1,0 +1,16 @@
+{
+  "domainName": "www.com.se",
+  "nameServers": [
+    "gene.ns.cloudflare.com",
+    "tim.ns.cloudflare.com"
+  ],
+  "dnssec": "unsigned delegation",
+  "creationDate": "2014-05-01",
+  "expirationDate": "2023-05-01Z",
+  "updatedDate": "2022-12-08",
+  "states": [
+    "ok"
+  ],
+  "owner": "C11480",
+  "registrar": "CentralNic Ltd"
+}

--- a/tests/Iodev/Whois/Modules/Tld/parsing_data/.com.se/www.com.se.txt
+++ b/tests/Iodev/Whois/Modules/Tld/parsing_data/.com.se/www.com.se.txt
@@ -1,0 +1,32 @@
+# For more information on Whois status codes, please visit https: //icann.org/epp
+#
+# >>> IMPORTANT INFORMATION ABOUT THE DEPLOYMENT OF RDAP: please visit
+# https: //www.centralnic.com/support/rdap <<<
+#
+# The Whois and RDAP services are provided by CentralNic, and contain
+# information pertaining to Internet domain names registered by our
+# our customers. By using this service you are agreeing (1) not to use any
+# information presented here for any purpose other than determining
+# ownership of domain names, (2) not to store or reproduce this data in
+# any way, (3) not to use any high-volume, automated, electronic processes
+# to obtain data from this service. Abuse of this service is monitored and
+# actions in contravention of these terms will result in being permanently
+# blacklisted. All data is (c) CentralNic Ltd (https: //www.centralnic.com)
+#
+# Access to the Whois and RDAP services is rate limited. For more
+# information, visit https: //registrar-console.centralnic.com/pub/whois_guidance.
+
+state:            active
+domain:           www.com.se
+holder:           C11480
+admin-c:          -
+tech-c:           -
+billing-c:        -
+created: 2014-05-01
+modified: 2022-12-08
+expires: 2023-05-01
+nserver:          gene.ns.cloudflare.com
+nserver:          tim.ns.cloudflare.com
+dnssec:           unsigned delegation
+status:           ok
+registrar:        CentralNic Ltd


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | no <!-- please add use-case examples to README.md -->
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes    <!-- please add some, will be required by reviewers -->
| License       | MIT

Addition of the .com.se extension managed by CentralNic
They are private domains resold by CentralNic, as it usually does with other "TLDs"

The official site: https://www.com.se
