### PR TITLE
Parse .nc nameservers

### DIFF
--- a/src/Iodev/Whois/Configs/module.tld.parser.common.json
+++ b/src/Iodev/Whois/Configs/module.tld.parser.common.json
@@ -16,10 +16,10 @@
   ],
   "nameServersKeysGroups": [
     [
-      "~^(ns\\s+1|primary\\s+server(\\s+hostname)?|ns_name_01)$~ui",
-      "~^(ns\\s+2|secondary\\s+server(\\s+hostname)?|ns_name_02)$~ui",
-      "~^(ns\\s+3|third\\s+server(\\s+hostname)?|ns_name_03)$~ui",
-      "~^(ns\\s+4|fourth\\s+server(\\s+hostname)?|ns_name_04)$~ui"
+      "~^(ns\\s+1|primary\\s+server(\\s+hostname)?|ns_name_01|domain\\s+server\\s+1)$~ui",
+      "~^(ns\\s+2|secondary\\s+server(\\s+hostname)?|ns_name_02|domain\\s+server\\s+2)$~ui",
+      "~^(ns\\s+3|third\\s+server(\\s+hostname)?|ns_name_03|domain\\s+server\\s+3)$~ui",
+      "~^(ns\\s+4|fourth\\s+server(\\s+hostname)?|ns_name_04|domain\\s+server\\s+4)$~ui"
     ]
   ],
   "dnssecKeys": [

--- a/tests/Iodev/Whois/Modules/Tld/TldParsingTest.php
+++ b/tests/Iodev/Whois/Modules/Tld/TldParsingTest.php
@@ -698,6 +698,9 @@ class TldParsingTest extends TestCase
             [ "free.navy", ".navy/free.txt", null ],
             [ "nic.navy", ".navy/nic.navy.txt", ".navy/nic.navy.json" ],
 
+            // .NA
+            [ "domaine.nc", ".nc/domaine.nc.txt", ".nc/domaine.nc.json" ],
+
             // .NET
             [ "free.net", ".net/free.txt", null ],
             [ "speedtest.net", ".net/speedtest.net.txt", ".net/speedtest.net.json" ],

--- a/tests/Iodev/Whois/Modules/Tld/parsing_data/.nc/domaine.nc.json
+++ b/tests/Iodev/Whois/Modules/Tld/parsing_data/.nc/domaine.nc.json
@@ -1,0 +1,12 @@
+{
+  "domainName": "domaine.nc",
+  "creationDate": "2006-05-14T00:00:00.000Z",
+  "expirationDate": "2027-05-14",
+  "updatedDate": "2021-04-14T10:13:34.000Z",
+  "nameServers": [
+    "nsopt1.opt.nc",
+    "nsopt2.opt.nc",
+    "nsopt3.opt.nc"
+  ],
+  "registrar": "NONE"
+}

--- a/tests/Iodev/Whois/Modules/Tld/parsing_data/.nc/domaine.nc.txt
+++ b/tests/Iodev/Whois/Modules/Tld/parsing_data/.nc/domaine.nc.txt
@@ -1,0 +1,12 @@
+OPT Whois v2.1.2
+
+Domain                   : domaine.nc
+Created on               : 2006-05-14T00:00:00.000Z
+Expires on               : 2027-05-14
+Last updated on          : 2021-04-14T10:13:34.000Z
+
+Domain server 1          : nsopt1.opt.nc
+Domain server 2          : nsopt2.opt.nc
+Domain server 3          : nsopt3.opt.nc
+
+Registrar                : NONE


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | no <!-- please add use-case examples to README.md -->
| BC breaks?    | no
| Deprecations? |no
| Tests pass?   | yes
| Fixed tickets | #189 
| License       | MIT

Small update of the regexp to parse the nameservers of the .NC tld

Also added a test.
