### PR TITLE
PHP 8.2 dynamic property deprecation

### DIFF
--- a/src/Iodev/Whois/Modules/Tld/Parsers/CommonParser.php
+++ b/src/Iodev/Whois/Modules/Tld/Parsers/CommonParser.php
@@ -10,6 +10,7 @@ use Iodev\Whois\Modules\Tld\TldInfo;
 use Iodev\Whois\Modules\Tld\TldResponse;
 use Iodev\Whois\Modules\Tld\TldParser;
 
+#[\AllowDynamicProperties]
 class CommonParser extends TldParser
 {
     /** @var string */


### PR DESCRIPTION
Since PHP 8.2 dynamic property creation is deprecated, but could be suppressed with `#[\AllowDynamicProperties]` annotation.

It fixes the deprecation warnings in tests:

```
PHP Deprecated:  Creation of dynamic property Iodev\Whois\Modules\Tld\Parsers\TestCommonParser::$parserTypes is deprecated in src/Iodev/Whois/Modules/Tld/Parsers/CommonParser.php on line 78
```

php82

| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | yes
| Tests pass?   | yes
| License       | MIT

<!--
Write a short README entry for your feature/bugfix here (replace this comment block.)
This will help to understand your PR.
-->
