### PR TITLE
Repair the error when the query is for multiple domain names

### DIFF
--- a/src/Iodev/Whois/Helpers/GroupHelper.php
+++ b/src/Iodev/Whois/Helpers/GroupHelper.php
@@ -80,11 +80,11 @@ class GroupHelper
             if (is_array($key)) {
                 self::matchSubKeys($group, $key, $matches);
             } elseif (isset($group[$key])) {
-                $matches[] = $group[$key];
+                is_array($group[$key]) ? $matches = array_merge($matches, $group[$key]) : $matches[] = $group[$key];
             } else {
                 foreach ($group as $groupKey => $groupVal) {
                     if ($matcher($key, $groupKey)) {
-                        $matches[] = $groupVal;
+                        is_array($groupVal) ? $matches = array_merge($matches, $groupVal) : $matches[] = $groupVal;
                         if ($firstOnly) {
                             break;
                         }


### PR DESCRIPTION
Repair the error when the query is for multiple domain names, e.g.: 张三.中国, contains 張三.中国 and 張三.中國 and 张三.中国 and 张三.中國
