### PR TITLE
Fix trim() on null error

### DIFF
--- a/src/Iodev/Whois/Helpers/ParserHelper.php
+++ b/src/Iodev/Whois/Helpers/ParserHelper.php
@@ -273,7 +273,7 @@ class ParserHelper
         foreach ($rawstates as $rawstate) {
             if (preg_match('/^\s*((\d{3}\s+)?[a-z]{2,}.*)\s*/ui', $rawstate, $m)) {
                 $state = mb_strtolower($m[1]);
-                $state = $removeExtra ? trim(preg_replace('~\(.+?\)|((- )?http|<a href).+~ui', '', $state)) : $state;
+                $state = $removeExtra ? trim((string)preg_replace('~\(.+?\)|((- )?http|<a href).+~ui', '', $state)) : $state;
 
                 if (!empty($state)) {
                     $states[] = $state;


### PR DESCRIPTION
TypeError: trim() expects parameter 1 to be string, null given in /Iodev/Whois/Helpers/ParserHelper.php:276

| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | yes/no
| New feature?  | yes/no <!-- please add use-case examples to README.md -->
| BC breaks?    | no
| Deprecations? | yes/no
| Tests pass?   | yes    <!-- please add some, will be required by reviewers -->
| Fixed tickets | #...   <!-- #-prefixed issue number(s), if any -->
| License       | MIT

<!--
Write a short README entry for your feature/bugfix here (replace this comment block.)
This will help to understand your PR.
-->
