### PR TITLE
Fix #225 - compatibility with PHP 8.4

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -3,19 +3,17 @@ on: [push, pull_request]
 jobs:
 
   php-intl:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-24.04
     strategy:
       fail-fast: false
       matrix:
-        php-version: ['7.2', '7.3', '7.4', '8.0', '8.1', '8.2']
+        php-version: ['7.2', '7.3', '7.4', '8.0', '8.1', '8.2', '8.3', '8.4']
 
     steps:
-      - uses: actions/checkout@v2
-        with:
-          fetch-depth: 1
+      - uses: actions/checkout@v4
 
-      - run: php${{ matrix.php-version }} -v
-      - run: php${{ matrix.php-version }} -m
-      - run: composer -V
+      - run: php -v
+      - run: php -m
+      - run: composer --version
       - run: composer install
-      - run: php${{ matrix.php-version }} vendor/bin/phpunit --bootstrap tests/bootstrap.php tests
+      - run: php vendor/bin/phpunit --bootstrap tests/bootstrap.php tests

--- a/src/Iodev/Whois/Exceptions/ConnectionException.php
+++ b/src/Iodev/Whois/Exceptions/ConnectionException.php
@@ -9,7 +9,7 @@ use Throwable;
 
 class ConnectionException extends Exception
 {
-    public function __construct($message = "", $code = 0, Throwable $previous = null)
+    public function __construct($message = "", $code = 0, ?Throwable $previous = null)
     {
         parent::__construct($message, $code, $previous);
     }

--- a/src/Iodev/Whois/Exceptions/ServerMismatchException.php
+++ b/src/Iodev/Whois/Exceptions/ServerMismatchException.php
@@ -8,7 +8,7 @@ use Throwable;
 
 class ServerMismatchException extends \Exception
 {
-    public function __construct($message = "", $code = 0, Throwable $previous = null)
+    public function __construct($message = "", $code = 0, ?Throwable $previous = null)
     {
         parent::__construct($message, $code, $previous);
     }

--- a/src/Iodev/Whois/Exceptions/WhoisException.php
+++ b/src/Iodev/Whois/Exceptions/WhoisException.php
@@ -8,7 +8,7 @@ use Throwable;
 
 class WhoisException extends \Exception
 {
-    public function __construct($message = "", $code = 0, Throwable $previous = null)
+    public function __construct($message = "", $code = 0, ?Throwable $previous = null)
     {
         parent::__construct($message, $code, $previous);
     }

--- a/src/Iodev/Whois/Factory.php
+++ b/src/Iodev/Whois/Factory.php
@@ -42,7 +42,7 @@ class Factory implements IFactory
      * @param ILoader|null $loader
      * @return Whois
      */
-    public function createWhois(ILoader $loader = null): Whois
+    public function createWhois(?ILoader $loader = null): Whois
     {
         $whois = new Whois($loader ?: $this->createLoader());
         $whois->setFactory($this);
@@ -84,7 +84,7 @@ class Factory implements IFactory
      * @param TldParser|null $defaultParser
      * @return TldServer[]
      */
-    public function createTldSevers($configs = null, TldParser $defaultParser = null): array
+    public function createTldSevers($configs = null, ?TldParser $defaultParser = null): array
     {
         $configs = is_array($configs) ? $configs : Config::load("module.tld.servers");
         $defaultParser = $defaultParser ?: $this->createTldParser();
@@ -100,7 +100,7 @@ class Factory implements IFactory
      * @param TldParser|null $defaultParser
      * @return TldServer
      */
-    public function createTldSever(array $config, TldParser $defaultParser = null): TldServer
+    public function createTldSever(array $config, ?TldParser $defaultParser = null): TldServer
     {
         return new TldServer(
             $config['zone'] ?? '',
@@ -116,7 +116,7 @@ class Factory implements IFactory
      * @param TldParser|null $defaultParser
      * @return TldParser
      */
-    public function createTldSeverParser(array $config, TldParser $defaultParser = null): TldParser
+    public function createTldSeverParser(array $config, ?TldParser $defaultParser = null): TldParser
     {
         $options = $config['parserOptions'] ?? [];
         if (isset($config['parserClass'])) {
@@ -204,7 +204,7 @@ class Factory implements IFactory
      * @param AsnParser $defaultParser
      * @return AsnServer[]
      */
-    public function createAsnSevers($configs = null, AsnParser $defaultParser = null): array
+    public function createAsnSevers($configs = null, ?AsnParser $defaultParser = null): array
     {
         $configs = is_array($configs) ? $configs : Config::load("module.asn.servers");
         $defaultParser = $defaultParser ?: $this->createAsnParser();
@@ -220,7 +220,7 @@ class Factory implements IFactory
      * @param AsnParser $defaultParser
      * @return AsnServer
      */
-    public function createAsnSever($config, AsnParser $defaultParser = null)
+    public function createAsnSever($config, ?AsnParser $defaultParser = null)
     {
         return new AsnServer(
             $config['host'] ?? '',
@@ -234,7 +234,7 @@ class Factory implements IFactory
      * @param AsnParser|null $defaultParser
      * @return AsnParser
      */
-    public function createAsnSeverParser(array $config, AsnParser $defaultParser = null): AsnParser
+    public function createAsnSeverParser(array $config, ?AsnParser $defaultParser = null): AsnParser
     {
         if (isset($config['parserClass'])) {
             return $this->createAsnParserByClass($config['parserClass']);

--- a/src/Iodev/Whois/Modules/Asn/AsnModule.php
+++ b/src/Iodev/Whois/Modules/Asn/AsnModule.php
@@ -57,7 +57,7 @@ class AsnModule extends Module
      * @throws ConnectionException
      * @throws WhoisException
      */
-    public function lookupAsn($asn, AsnServer $server = null)
+    public function lookupAsn($asn, ?AsnServer $server = null)
     {
         if ($server) {
             return $this->loadResponse($asn, $server);
@@ -73,7 +73,7 @@ class AsnModule extends Module
      * @throws ConnectionException
      * @throws WhoisException
      */
-    public function loadAsnInfo($asn, AsnServer $server = null)
+    public function loadAsnInfo($asn, ?AsnServer $server = null)
     {
         if ($server) {
             $resp = $this->loadResponse($asn, $server);

--- a/src/Iodev/Whois/Modules/Tld/Parsers/CommonParser.php
+++ b/src/Iodev/Whois/Modules/Tld/Parsers/CommonParser.php
@@ -12,6 +12,9 @@ use Iodev\Whois\Modules\Tld\TldParser;
 
 class CommonParser extends TldParser
 {
+    /** @var array */
+    protected $parserTypes = [];
+
     /** @var string */
     protected $headerKey = 'HEADER';
 

--- a/src/Iodev/Whois/Modules/Tld/TldModule.php
+++ b/src/Iodev/Whois/Modules/Tld/TldModule.php
@@ -116,7 +116,7 @@ class TldModule extends Module
      * @throws ConnectionException
      * @throws WhoisException
      */
-    public function lookupDomain($domain, TldServer $server = null)
+    public function lookupDomain($domain, ?TldServer $server = null)
     {
         $servers = $server ? [$server] : $this->matchServers($domain);
         list ($response) = $this->loadDomainData($domain, $servers);
@@ -131,7 +131,7 @@ class TldModule extends Module
      * @throws ConnectionException
      * @throws WhoisException
      */
-    public function loadDomainInfo($domain, TldServer $server = null)
+    public function loadDomainInfo($domain, ?TldServer $server = null)
     {
         $servers = $server ? [$server] : $this->matchServers($domain);
         list (, $info) = $this->loadDomainData($domain, $servers);

--- a/src/Iodev/Whois/Modules/Tld/TldServer.php
+++ b/src/Iodev/Whois/Modules/Tld/TldServer.php
@@ -20,7 +20,7 @@ class TldServer
      * @param TldParser $defaultParser
      * @return TldServer
      */
-    public static function fromData($data, TldParser $defaultParser = null)
+    public static function fromData($data, ?TldParser $defaultParser = null)
     {
         return Factory::get()->createTldSever($data, $defaultParser);
     }
@@ -30,7 +30,7 @@ class TldServer
      * @param TldParser $defaultParser
      * @return TldServer[]
      */
-    public static function fromDataList($dataList, TldParser $defaultParser = null)
+    public static function fromDataList($dataList, ?TldParser $defaultParser = null)
     {
         return Factory::get()->createTldSevers($dataList, $defaultParser);
     }
@@ -42,7 +42,7 @@ class TldServer
      * @param TldParser $parser
      * @param string $queryFormat
      */
-    public function __construct($zone, $host, $centralized, TldParser $parser, $queryFormat = null)
+    public function __construct($zone, $host, $centralized, ?TldParser $parser, $queryFormat = null)
     {
         $this->uid = ++self::$counter;
         $this->zone = strval($zone);
@@ -76,7 +76,7 @@ class TldServer
 
     /** @var string */
     protected $host;
-    
+
     /** @var TldParser */
     protected $parser;
 

--- a/src/Iodev/Whois/WhoisDeprecated.php
+++ b/src/Iodev/Whois/WhoisDeprecated.php
@@ -13,7 +13,7 @@ trait WhoisDeprecated
      * @param ILoader $loader
      * @return Whois
      */
-    public static function create(ILoader $loader = null)
+    public static function create(?ILoader $loader = null)
     {
         return Factory::get()->createWhois($loader);
     }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes (except an unrelated test which fails in the existing code)
| Fixed tickets | #255
| License       | MIT

This fix contains two changes for compatibility with PHP 8.4

* Implicit null function parameters changed to explicit null.  e.g. `(Foo $foo = null)` becomes `(?Foo $foo = null`)`
* Add new property to `CommonParser`, prevent "cannot create dynamic properties"

It also updates the test script to include recent versions of PHP.