### PR TITLE
Fix TypeError in BlockParser::parseDate with fallback regex

### DIFF
--- a/src/Iodev/Whois/Modules/Tld/Parsers/BlockParser.php
+++ b/src/Iodev/Whois/Modules/Tld/Parsers/BlockParser.php
@@ -434,6 +434,17 @@ class BlockParser extends CommonParser
                 }
             }
         }
+        foreach ($sel->getAll() as $value) {
+            $strs = is_array($value) ? $value : [$value];
+            foreach ($strs as $str) {
+                if ($str && preg_match($fallbackRegex, $str)) {
+                    $time = DateHelper::parseDateInText($str);
+                    if (!empty($time)) {
+                        return $time;
+                    }
+                }
+            }
+        }
         return 0;
     }
 

--- a/src/Iodev/Whois/Modules/Tld/Parsers/BlockParser.php
+++ b/src/Iodev/Whois/Modules/Tld/Parsers/BlockParser.php
@@ -426,14 +426,6 @@ class BlockParser extends CommonParser
         if (empty($fallbackRegex)) {
             return 0;
         }
-        foreach ($sel->getAll() as $str) {
-            if ($str && preg_match($fallbackRegex, $str)) {
-                $time = DateHelper::parseDateInText($str);
-                if (!empty($time)) {
-                    return $time;
-                }
-            }
-        }
         foreach ($sel->getAll() as $value) {
             $strs = is_array($value) ? $value : [$value];
             foreach ($strs as $str) {

--- a/tests/Iodev/Whois/Modules/Tld/TldParsingTest.php
+++ b/tests/Iodev/Whois/Modules/Tld/TldParsingTest.php
@@ -350,6 +350,7 @@ class TldParsingTest extends TestCase
             [ "free.com", ".com/free.txt", null ],
             [ "google.com", ".com/google.com.txt", ".com/google.com.json" ],
             [ "google.com", ".com/google.com_registrar_whois.txt", ".com/google.com_registrar_whois.json" ],
+            [ "semihkoyuturk.com", ".com/semihkoyuturk.com.txt", ".com/semihkoyuturk.com.json" ],
 
             // .CR
             [ "free.cr", ".cr/free.txt", null ],

--- a/tests/Iodev/Whois/Modules/Tld/parsing_data/.com/semihkoyuturk.com.json
+++ b/tests/Iodev/Whois/Modules/Tld/parsing_data/.com/semihkoyuturk.com.json
@@ -6,12 +6,10 @@
     "ns2.infinityfree.com"
   ],
   "dnssec": "unsigned",
-  "creationDate": "2016-03-25T19:40:34Z",
-  "expirationDate": "2026-03-25T19:40:34Z",
-  "updatedDate": "2025-06-01T10:30:25Z",
-  "states": [
-    "clienttransferprohibited"
-  ],
+  "creationDate": "",
+  "expirationDate": "2026-03-25T22:40:34Z",
+  "updatedDate": "",
+  "states": [],
   "owner": "n/a",
-  "registrar": "Atak Domain Bilgi Teknolojileri A.S."
+  "registrar": "Atak Domain"
 }

--- a/tests/Iodev/Whois/Modules/Tld/parsing_data/.com/semihkoyuturk.com.json
+++ b/tests/Iodev/Whois/Modules/Tld/parsing_data/.com/semihkoyuturk.com.json
@@ -1,0 +1,17 @@
+{
+  "domainName": "semihkoyuturk.com",
+  "whoisServer": "whois.apiname.com",
+  "nameServers": [
+    "ns1.infinityfree.com",
+    "ns2.infinityfree.com"
+  ],
+  "dnssec": "unsigned",
+  "creationDate": "2016-03-25T19:40:34Z",
+  "expirationDate": "2026-03-25T19:40:34Z",
+  "updatedDate": "2025-06-01T10:30:25Z",
+  "states": [
+    "clienttransferprohibited"
+  ],
+  "owner": "",
+  "registrar": "Atak Domain"
+}

--- a/tests/Iodev/Whois/Modules/Tld/parsing_data/.com/semihkoyuturk.com.json
+++ b/tests/Iodev/Whois/Modules/Tld/parsing_data/.com/semihkoyuturk.com.json
@@ -12,6 +12,6 @@
   "states": [
     "clienttransferprohibited"
   ],
-  "owner": "",
-  "registrar": "Atak Domain"
+  "owner": "n/a",
+  "registrar": "Atak Domain Bilgi Teknolojileri A.S."
 }

--- a/tests/Iodev/Whois/Modules/Tld/parsing_data/.com/semihkoyuturk.com.txt
+++ b/tests/Iodev/Whois/Modules/Tld/parsing_data/.com/semihkoyuturk.com.txt
@@ -1,0 +1,131 @@
+   Domain Name: SEMIHKOYUTURK.COM
+   Registry Domain ID: 2015881728_DOMAIN_COM-VRSN
+   Registrar WHOIS Server: whois.apiname.com
+   Registrar URL: http://www.apiname.com
+   Updated Date: 2025-06-01T10:30:25Z
+   Creation Date: 2016-03-25T19:40:34Z
+   Registry Expiry Date: 2026-03-25T19:40:34Z
+   Registrar: Atak Domain Bilgi Teknolojileri A.S.
+   Registrar IANA ID: 1601
+   Registrar Abuse Contact Email: domain@apiname.com
+   Registrar Abuse Contact Phone: +90.2623259222
+   Domain Status: clientTransferProhibited https://icann.org/epp#clientTransferProhibited
+   Name Server: NS1.INFINITYFREE.COM
+   Name Server: NS2.INFINITYFREE.COM
+   DNSSEC: unsigned
+   URL of the ICANN Whois Inaccuracy Complaint Form: https://www.icann.org/wicf/
+>>> Last update of whois database: 2025-08-31T14:22:22Z <<<
+
+For more information on Whois status codes, please visit https://icann.org/epp
+
+NOTICE: The expiration date displayed in this record is the date the
+registrar's sponsorship of the domain name registration in the registry is
+currently set to expire. This date does not necessarily reflect the expiration
+date of the domain name registrant's agreement with the sponsoring
+registrar.  Users may consult the sponsoring registrar's Whois database to
+view the registrar's reported date of expiration for this registration.
+
+TERMS OF USE: You are not authorized to access or query our Whois
+database through the use of electronic processes that are high-volume and
+automated except as reasonably necessary to register domain names or
+modify existing registrations; the Data in VeriSign Global Registry
+Services' ("VeriSign") Whois database is provided by VeriSign for
+information purposes only, and to assist persons in obtaining information
+about or related to a domain name registration record. VeriSign does not
+guarantee its accuracy. By submitting a Whois query, you agree to abide
+by the following terms of use: You agree that you may use this Data only
+for lawful purposes and that under no circumstances will you use this Data
+to: (1) allow, enable, or otherwise support the transmission of mass
+unsolicited, commercial advertising or solicitations via e-mail, telephone,
+or facsimile; or (2) enable high volume, automated, electronic processes
+that apply to VeriSign (or its computer systems). The compilation,
+repackaging, dissemination or other use of this Data is expressly
+prohibited without the prior written consent of VeriSign. You agree not to
+use electronic processes that are automated and high-volume to access or
+query the Whois database except as reasonably necessary to register
+domain names or modify existing registrations. VeriSign reserves the right
+to restrict your access to the Whois database in its sole discretion to ensure
+operational stability.  VeriSign may restrict or terminate your access to the
+Whois database for failure to abide by these terms of use. VeriSign
+reserves the right to modify these terms at any time.
+
+The Registry database contains ONLY .COM, .NET, .EDU domains and
+Registrars.
+Domain Name: semihkoyuturk.com
+Registry Domain ID: 2015881728_DOMAIN_COM-VRSN
+Registrar WHOIS Server: whois.apiname.com
+Registrar URL: http://apiname.com
+Updated Date:
+Creation Date:
+Registrar Registration Expiration Date: 2026-03-25T22:40:34Z
+Registrar: Atak Domain
+Registrar IANA ID: 1601
+Registrar Abuse Contact Email: domain@apiname.com
+Registrar Abuse Contact Phone: +90.2623259222
+Reseller: G�zel Hosting
+Domain Status: http://www.icann.org/epp#clientTransferProhibited
+Registry Registrant ID: DNA-DN-17639910
+Registrant Name: Guzel Hosting Musteri
+Registrant Organization: n/a
+Registrant Street: Icerenkoy Mh. Ertac Sk.
+Registrant Street: Ardil Is Merkezi 4/2
+Registrant Street:
+Registrant City: Istanbul
+Registrant State/Province: Atasehir
+Registrant Postal Code: 34752
+Registrant Country: TR
+Registrant Phone: +90.8508850558
+Registrant Phone Ext:
+Registrant Fax:
+Registrant Fax Ext:
+Registrant Email: bildirim@guzel.net.tr
+Registry Admin ID: DNA-DN-17639910
+Admin Name: Guzel Hosting Musteri
+Admin Organization: n/a
+Admin Street: Icerenkoy Mh. Ertac Sk.
+Admin Street: Ardil Is Merkezi 4/2
+Admin Street:
+Admin City: Istanbul
+Admin State/Province: Atasehir
+Admin Postal Code: 34752
+Admin Country: TR
+Admin Phone: +90.8508850558
+Admin Phone Ext:
+Admin Fax:
+Admin Fax Ext:
+Admin Email: bildirim@guzel.net.tr
+Registry Tech ID: DNA-DN-17639910
+Tech Name: Guzel Hosting Musteri
+Tech Organization: n/a
+Tech Street: Icerenkoy Mh. Ertac Sk.
+Tech Street: Ardil Is Merkezi 4/2
+Tech Street:
+Tech City: Istanbul
+Tech State/Province: Atasehir
+Tech Postal Code: 34752
+Tech Country: TR
+Tech Phone: +90.8508850558
+Tech Phone Ext:
+Tech Fax:
+Tech Fax Ext:
+Tech Email: bildirim@guzel.net.tr
+Name Server: ns1.infinityfree.com
+Name Server: ns2.infinityfree.com
+DNSSEC: unsigned
+URL of the ICANN WHOIS Data Problem Reporting System: http://wdprs.internic.net/
+>>> Last update of WHOIS database: 2025-08-25T02:32:48.670Z <<<
+
+For more information on Whois status codes, please visit https://www.icann.org/resources/pages/epp-status-codes-2014-06-16-en.
+This data is provided for information purposes, and to assist persons
+obtaining information about or related to domain name registration
+records. We do not guarantee its accuracy.
+By submitting a WHOIS query, you agree that you will use this data
+only for lawful purposes and that, under no circumstances, you will
+use this data to
+1) allow, enable, or otherwise support the transmission of mass
+unsolicited, commercial advertising or solicitations via E-mail
+(spam); or
+2) enable high volume, automated, electronic processes that apply
+to this WHOIS server.
+These terms may be changed without prior notice.
+By submitting this query, you agree to abide by this policy.

--- a/tests/Iodev/Whois/Modules/Tld/parsing_data/.com/semihkoyuturk.com.txt
+++ b/tests/Iodev/Whois/Modules/Tld/parsing_data/.com/semihkoyuturk.com.txt
@@ -1,56 +1,3 @@
-   Domain Name: SEMIHKOYUTURK.COM
-   Registry Domain ID: 2015881728_DOMAIN_COM-VRSN
-   Registrar WHOIS Server: whois.apiname.com
-   Registrar URL: http://www.apiname.com
-   Updated Date: 2025-06-01T10:30:25Z
-   Creation Date: 2016-03-25T19:40:34Z
-   Registry Expiry Date: 2026-03-25T19:40:34Z
-   Registrar: Atak Domain Bilgi Teknolojileri A.S.
-   Registrar IANA ID: 1601
-   Registrar Abuse Contact Email: domain@apiname.com
-   Registrar Abuse Contact Phone: +90.2623259222
-   Domain Status: clientTransferProhibited https://icann.org/epp#clientTransferProhibited
-   Name Server: NS1.INFINITYFREE.COM
-   Name Server: NS2.INFINITYFREE.COM
-   DNSSEC: unsigned
-   URL of the ICANN Whois Inaccuracy Complaint Form: https://www.icann.org/wicf/
->>> Last update of whois database: 2025-08-31T14:22:22Z <<<
-
-For more information on Whois status codes, please visit https://icann.org/epp
-
-NOTICE: The expiration date displayed in this record is the date the
-registrar's sponsorship of the domain name registration in the registry is
-currently set to expire. This date does not necessarily reflect the expiration
-date of the domain name registrant's agreement with the sponsoring
-registrar.  Users may consult the sponsoring registrar's Whois database to
-view the registrar's reported date of expiration for this registration.
-
-TERMS OF USE: You are not authorized to access or query our Whois
-database through the use of electronic processes that are high-volume and
-automated except as reasonably necessary to register domain names or
-modify existing registrations; the Data in VeriSign Global Registry
-Services' ("VeriSign") Whois database is provided by VeriSign for
-information purposes only, and to assist persons in obtaining information
-about or related to a domain name registration record. VeriSign does not
-guarantee its accuracy. By submitting a Whois query, you agree to abide
-by the following terms of use: You agree that you may use this Data only
-for lawful purposes and that under no circumstances will you use this Data
-to: (1) allow, enable, or otherwise support the transmission of mass
-unsolicited, commercial advertising or solicitations via e-mail, telephone,
-or facsimile; or (2) enable high volume, automated, electronic processes
-that apply to VeriSign (or its computer systems). The compilation,
-repackaging, dissemination or other use of this Data is expressly
-prohibited without the prior written consent of VeriSign. You agree not to
-use electronic processes that are automated and high-volume to access or
-query the Whois database except as reasonably necessary to register
-domain names or modify existing registrations. VeriSign reserves the right
-to restrict your access to the Whois database in its sole discretion to ensure
-operational stability.  VeriSign may restrict or terminate your access to the
-Whois database for failure to abide by these terms of use. VeriSign
-reserves the right to modify these terms at any time.
-
-The Registry database contains ONLY .COM, .NET, .EDU domains and
-Registrars.
 Domain Name: semihkoyuturk.com
 Registry Domain ID: 2015881728_DOMAIN_COM-VRSN
 Registrar WHOIS Server: whois.apiname.com
@@ -62,7 +9,7 @@ Registrar: Atak Domain
 Registrar IANA ID: 1601
 Registrar Abuse Contact Email: domain@apiname.com
 Registrar Abuse Contact Phone: +90.2623259222
-Reseller: G�zel Hosting
+Reseller: G?zel Hosting
 Domain Status: http://www.icann.org/epp#clientTransferProhibited
 Registry Registrant ID: DNA-DN-17639910
 Registrant Name: Guzel Hosting Musteri


### PR DESCRIPTION
Fixes #220

| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #220 
| License       | MIT

The issue is that sometimes the WHOIS output contains the same key multiple times in places where it's not expected.

One particular domain name I had this issue with had WHOIS output looking like this:

```
Registrant Name: John Doe
Registrant Organization: n/a
Registrant Street: Example Street 420
Registrant Street: Apt. 42
Registrant Street: 
Registrant City: Testertown
```

The `ParserHelper::linesToGroups` function turns this structure into something like this (formatted as YAML here):

```yaml
Registrant Name: John Doe
Registrant Organization: n/a
Registrant Street: 
- Example Street 420
- Apt. 42
- ""
Registrant City: Testertown
```

Turning duplicate keys into an array is more or less expected, because duplicate keys are common and sometimes different, and then all values are relevant (i.e. the `Name Server` key).

The date parser assumes that all keys it gets are single keys, but that's not the case here, and that's what causes it to break.